### PR TITLE
Adding Chaotic AUR for prebuild AUR packages

### DIFF
--- a/add_chaotic_aur/post_bootstrap.sh
+++ b/add_chaotic_aur/post_bootstrap.sh
@@ -1,0 +1,11 @@
+printf '\e[1;32m-->\e[0m\e[1m Adding Chaotic AUR\e[0m\n'
+arch-chroot "$workdir" bash -c "
+  pacman-key --init
+  pacman-key --populate archlinux
+  pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com
+  pacman-key --lsign-key 3056513887B78AEB
+  pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst'
+  pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
+  echo -e '\n[chaotic-aur]\nInclude = /etc/pacman.d/chaotic-mirrorlist' >> /etc/pacman.conf
+  pacman -Sy
+"


### PR DESCRIPTION
This adds before installing packages from the packages.list the option to pull packages from the chaotic AUR which you can define packages from that repo in packages.list like arkane and arch repo packages.